### PR TITLE
Underscore as a dependency

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,6 +1,5 @@
 'use strict';
 var mongoose = require('mongoose');
-var _ = require('underscore');
 var util = require('util');
 
 module.exports.loadType = function(mongoose) {
@@ -19,7 +18,7 @@ function Currency(path, options) {
 util.inherits(Currency, mongoose.SchemaTypes.Number);
 
 Currency.prototype.cast = function(val) {
-  if ( _.isString(val) ) {
+  if ( isType('String', val) ) {
     var currencyAsString = val.toString();
     var findDigitsAndDotRegex = /\d*\.\d{1,2}/;
     var findCommasAndLettersRegex = /\,+|[a-zA-Z]+/g;
@@ -32,9 +31,20 @@ Currency.prototype.cast = function(val) {
     } else{
       return (currency * 100).toFixed(0) * 1;
     }
-  } else if ( _.isNumber(val) ) {
+  } else if ( isType('Number', val) ) {
     return val.toFixed(0) * 1;
   } else {
     return new Error('Should pass in a number or string');
   }
 };
+
+/**
+ * isType(type, obj)
+ * Supported types: 'Function', 'String', 'Number', 'Date', 'RegExp',
+ * 'Arguments'
+ * source: https://github.com/jashkenas/underscore/blob/1.5.2/underscore.js#L996
+ */
+
+function isType(type, obj) {
+  return Object.prototype.toString.call(obj) == '[object ' + type + ']';
+}

--- a/package.json
+++ b/package.json
@@ -22,9 +22,6 @@
   "license": "MIT",
   "readmeFilename": "README.md",
   "gitHead": "80f9b6fa07591917779b470a3a92c6fe3aadd9fe",
-  "dependencies": {
-    "underscore": "1.x"
-  },
   "devDependencies": {
     "mocha": "1.9.x",
     "should": "*",


### PR DESCRIPTION
Hey there!

Well, there are a few things here, and I actually messed up this PR, by changing my mind in the middle of the process.

My initial point was that underscore wasn't included as a dependency in the package.json - though it was a dependency.

I then realized that you were only using underscore for `isString` and `isNumber`, which are really trivial and short to implement, and therefore, don't really make up for including a big lib such as underscore in this tiny module (even if they couldn't in this context be replaced by the builtin `instanceof` - IDK about this, but I assumed there was some reason to use underscore's functions). _See [its source](https://github.com/jashkenas/underscore/blob/1.5.2/underscore.js#L996) if you're curious._

So I ditched underscore and added a general custom function to do the exact same thing.

I also made a commit transitioning your main module to strict mode, linting your code and using nodejs standard [`util.inherits`](http://nodejs.org/docs/latest/api/util.html#util_util_inherits_constructor_superconstructor) rather than the deprecated `prototype.__proto__` method.

I know most of these changes are kind of too opinionated and that I can be annoying with these sort of things, but please consider these changes and feel free to comment/cherry-pick.

**The only crucial thing would be to add underscore as a dependency - which is the first commit.**

Thanks and cheers!
