### PR TITLE
Deleting the deprecated function inherits

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,6 +1,5 @@
 'use strict';
 var mongoose = require('mongoose');
-var util = require('util');
 
 module.exports.loadType = function(mongoose) {
   mongoose.Types.Currency = mongoose.SchemaTypes.Currency = Currency;
@@ -15,7 +14,7 @@ function Currency(path, options) {
  * inherits
  */
 
-util.inherits(Currency, mongoose.SchemaTypes.Number);
+Currency.prototype = mongoose.SchemaTypes.Number.prototype;
 
 Currency.prototype.cast = function(val) {
   if ( isType('String', val) ) {

--- a/package.json
+++ b/package.json
@@ -25,9 +25,9 @@
   "devDependencies": {
     "mocha": "1.9.x",
     "should": "6.0.x",
-    "mongoose": "~> 4.x"
+    "mongoose": "^5.4.7"
   },
   "peerDependencies": {
-    "mongoose": "~> 4.x"
+    "mongoose": "^5.4.7"
   }
 }


### PR DESCRIPTION
The current version didn't inherit correctly all the prototype from the mongoose.SchemaTypes.Number's prototype because of the deprecated function of util library: inherits. 